### PR TITLE
Add block user functionality

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -20,6 +20,7 @@ import { checkMessageLimit } from './functions/check-message-limit/resource';
 import { removePremium } from './functions/remove-premium/resource';
 import { createReport } from './functions/create-report/resource';
 import { generateCompatibilityInsights } from './functions/generate-compatibility-insights/resource';
+import { blockUser } from './functions/block-user/resource';
 
 import * as iam from 'aws-cdk-lib/aws-iam';
 
@@ -44,7 +45,8 @@ const backend = defineBackend({
   checkMessageLimit,
   removePremium,
   createReport,
-  generateCompatibilityInsights
+  generateCompatibilityInsights,
+  blockUser
 });
 
 
@@ -171,6 +173,7 @@ backend.removePremium.resources.lambda.addToRolePolicy(new iam.PolicyStatement({
 }));
 
 const reportTableArn = `arn:aws:dynamodb:us-east-1:${process.env['AWS_ACCOUNT_ID']}:table/${backend.data.resources.tables["Report"].tableName}`;
+const blockTableArn = `arn:aws:dynamodb:us-east-1:${process.env['AWS_ACCOUNT_ID']}:table/${backend.data.resources.tables["UserBlock"].tableName}`;
 
 backend.createReport.resources.lambda.addToRolePolicy(new iam.PolicyStatement({
   actions: [
@@ -182,6 +185,11 @@ backend.createReport.resources.lambda.addToRolePolicy(new iam.PolicyStatement({
     'dynamodb:Scan'
   ],
   resources: [reportTableArn]
+}));
+
+backend.blockUser.resources.lambda.addToRolePolicy(new iam.PolicyStatement({
+  actions: ['dynamodb:PutItem'],
+  resources: [blockTableArn]
 }));
 
 backend.createReport.resources.lambda.addToRolePolicy(new iam.PolicyStatement({
@@ -197,3 +205,4 @@ backend.generateCompatibilityInsights.resources.lambda.addToRolePolicy(new iam.P
 
 // Add this after the reportTableArn definition
 backend.createReport.addEnvironment("AMPLIFY_REPORT_TABLE_NAME", backend.data.resources.tables["Report"].tableName);
+backend.blockUser.addEnvironment("AMPLIFY_USER_BLOCK_TABLE_NAME", backend.data.resources.tables["UserBlock"].tableName);

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -17,6 +17,7 @@ import { enrollPremium } from '../functions/enroll-premium/resource';
 import { removePremium } from '../functions/remove-premium/resource';
 import { createReport } from '../functions/create-report/resource';
 import { generateCompatibilityInsights } from '../functions/generate-compatibility-insights/resource';
+import { blockUser } from '../functions/block-user/resource';
 
 /* --- Define Models --- */
 export const ChatMessage = a.model({
@@ -108,6 +109,18 @@ const Report = a.model({
     index('reporterId').sortKeys(['createdAt']),
     index('reportedUserId').sortKeys(['createdAt']),
     index('status').sortKeys(['createdAt'])
+  ])
+  .authorization(allow => [allow.authenticated()]);
+
+const UserBlock = a.model({
+  id: a.id().required(),
+  userId: a.string().required(),
+  blockedUserId: a.string().required(),
+  createdAt: a.datetime().required()
+})
+  .secondaryIndexes(index => [
+    index('userId').sortKeys(['blockedUserId']),
+    index('blockedUserId').sortKeys(['userId'])
   ])
   .authorization(allow => [allow.authenticated()]);
 
@@ -225,6 +238,12 @@ const schema = a.schema({
     .handler(a.handler.function(removePremium))
     .authorization(allow => [allow.authenticated()]),
 
+  blockUser: a.mutation()
+    .arguments({ blockedUserId: a.string().required() })
+    .returns(a.ref('UserBlock'))
+    .handler(a.handler.function(blockUser))
+    .authorization(allow => [allow.authenticated()]),
+
   customCreateReport: a.mutation()
     .arguments({ 
       reportedUserId: a.string().required(),
@@ -251,6 +270,7 @@ const schema = a.schema({
   TypingStatus,
   UserPresence,
   Report,
+  UserBlock,
   CompatibilityInsights
 });
 

--- a/amplify/functions/block-user/handler.ts
+++ b/amplify/functions/block-user/handler.ts
@@ -1,0 +1,27 @@
+import { DynamoDB } from 'aws-sdk';
+import type { Schema } from '../../data/resource';
+import { getIdentityId } from '../../shared/utils/identity';
+
+const docClient = new DynamoDB.DocumentClient();
+const TABLE_NAME = process.env['USER_BLOCK_TABLE_NAME']!;
+
+export const handler: Schema['blockUser']['functionHandler'] = async (event) => {
+  const userId = getIdentityId(event.identity);
+  const blockedUserId = event.arguments.blockedUserId as string;
+
+  if (!userId || !blockedUserId) {
+    throw new Error('Missing userId or blockedUserId');
+  }
+
+  const item = {
+    id: `${userId}-${blockedUserId}`,
+    userId,
+    blockedUserId,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  };
+
+  await docClient.put({ TableName: TABLE_NAME, Item: item }).promise();
+
+  return item;
+};

--- a/amplify/functions/block-user/resource.ts
+++ b/amplify/functions/block-user/resource.ts
@@ -1,0 +1,9 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+export const blockUser = defineFunction({
+  name: 'block-user',
+  entry: './handler.ts',
+  environment: {
+    USER_BLOCK_TABLE_NAME: process.env['AMPLIFY_USER_BLOCK_TABLE_NAME']!
+  }
+});

--- a/src/app/components/block-user/block-user.component.html
+++ b/src/app/components/block-user/block-user.component.html
@@ -1,0 +1,13 @@
+<h2 mat-dialog-title class="text-center">Block User</h2>
+
+<mat-dialog-content>
+  <p>Are you sure you want to block <strong>{{ data.userName }}</strong>?</p>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" class="flex gap-2">
+  <button mat-button mat-dialog-close [disabled]="isSubmitting">Cancel</button>
+  <button mat-raised-button color="warn" (click)="confirmBlock()" [disabled]="isSubmitting">
+    <span *ngIf="!isSubmitting">Block</span>
+    <span *ngIf="isSubmitting">Blocking...</span>
+  </button>
+</mat-dialog-actions>

--- a/src/app/components/block-user/block-user.component.scss
+++ b/src/app/components/block-user/block-user.component.scss
@@ -1,0 +1,15 @@
+:host {
+  display: block;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.flex {
+  display: flex;
+}
+
+.gap-2 {
+  gap: 0.5rem;
+}

--- a/src/app/components/block-user/block-user.component.ts
+++ b/src/app/components/block-user/block-user.component.ts
@@ -1,0 +1,37 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { BlockService } from '../../services/block.service';
+import { ToastMessageService } from '../../services/toast-message.service';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-block-user',
+  templateUrl: './block-user.component.html',
+  styleUrls: ['./block-user.component.scss'],
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule]
+})
+export class BlockUserComponent {
+  isSubmitting = false;
+
+  constructor(
+    public dialogRef: MatDialogRef<BlockUserComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { blockedUserId: string; userName: string },
+    private blockService: BlockService,
+    private toastService: ToastMessageService
+  ) {}
+
+  confirmBlock(): void {
+    this.isSubmitting = true;
+    this.blockService.blockUser(this.data.blockedUserId).subscribe({
+      next: () => {
+        this.toastService.success('User blocked successfully.', 'Close');
+        this.dialogRef.close(true);
+      },
+      error: () => {
+        this.isSubmitting = false;
+      }
+    });
+  }
+}

--- a/src/app/components/chat/chat.component.html
+++ b/src/app/components/chat/chat.component.html
@@ -57,14 +57,23 @@
           >
             {{ recipientUserName$ | async }}
           </div>
-          <button 
+          <button
             *ngIf="msg.senderId !== currentUserId"
-            mat-icon-button 
+            mat-icon-button
             class="report-button"
             (click)="openReportDialog(msg)"
             matTooltip="Report this message"
           >
             <mat-icon>flag</mat-icon>
+          </button>
+          <button
+            *ngIf="msg.senderId !== currentUserId"
+            mat-icon-button
+            class="block-button"
+            (click)="openBlockDialog()"
+            matTooltip="Block this user"
+          >
+            <mat-icon>block</mat-icon>
           </button>
         </div>
         <div class="text">{{ msg.text }}</div>

--- a/src/app/components/chat/chat.component.scss
+++ b/src/app/components/chat/chat.component.scss
@@ -337,6 +337,20 @@
   }
 }
 
+.block-button {
+  width: 24px;
+  height: 24px;
+  line-height: 24px;
+  color: var(--theme-warn);
+  opacity: 0.7;
+  transition: opacity 0.2s;
+  margin-top:-20px;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
 .report-icon {
   font-size: 16px;
   width: 16px;

--- a/src/app/components/chat/chat.component.ts
+++ b/src/app/components/chat/chat.component.ts
@@ -18,6 +18,7 @@ import { UserProfileState } from '../../store/states/user-profile.state';
 import { LoadUserProfile } from '../../store/actions/user-profile.actions';
 import { MatDialog } from '@angular/material/dialog';
 import { ReportUserComponent } from '../report-user/report-user.component';
+import { BlockUserComponent } from '../block-user/block-user.component';
 // import { ChatReactionComponent } from './chat-reaction/chat-reaction.component'; // adjust path if needed
 
 @Component({
@@ -25,7 +26,7 @@ import { ReportUserComponent } from '../report-user/report-user.component';
   templateUrl: './chat.component.html',
   styleUrls: ['./chat.component.scss'],
   standalone: true,
-  imports: [CommonModule, FormsModule, MaterialModule, ImageDisplayComponent, LoadingComponent]
+  imports: [CommonModule, FormsModule, MaterialModule, ImageDisplayComponent, LoadingComponent, BlockUserComponent, ReportUserComponent]
 })
 export class ChatComponent implements OnInit, OnDestroy {
   @ViewChild('messagesContainer') private messagesContainer!: ElementRef;
@@ -221,6 +222,22 @@ export class ChatComponent implements OnInit, OnDestroy {
       if (result) {
         // Show success message
         // You might want to add a snackbar service for this
+      }
+    });
+  }
+
+  openBlockDialog(): void {
+    const dialogRef = this.dialog.open(BlockUserComponent, {
+      data: {
+        blockedUserId: this.recipientId,
+        userName: this.store.selectSnapshot(UserProfileState.getUserNameById)?.(this.recipientId) || 'User'
+      }
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        // Navigate away from chat after blocking
+        this.router.navigate(['/chat-list']);
       }
     });
   }

--- a/src/app/services/block.service.ts
+++ b/src/app/services/block.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { generateClient } from 'aws-amplify/data';
+import type { Schema } from '../../../amplify/data/resource';
+import { from, Observable } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { ToastMessageService } from './toast-message.service';
+
+const client = generateClient<Schema>();
+
+@Injectable({ providedIn: 'root' })
+export class BlockService {
+  constructor(private toastService: ToastMessageService) {}
+
+  blockUser(blockedUserId: string): Observable<any> {
+    return from(client.mutations.blockUser({ blockedUserId })).pipe(
+      map((result: any) => {
+        if (result.errors?.length) {
+          throw new Error('GraphQL error: ' + result.errors.join(', '));
+        }
+        return result.data;
+      }),
+      catchError(err => {
+        console.error('Error blocking user:', err);
+        this.toastService.error('Failed to block user. Please try again.', 'Close');
+        throw err;
+      })
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `UserBlock` data model and `blockUser` mutation
- add `block-user` Lambda to insert block records
- expose block mutation in backend and grant IAM permissions
- create Angular `BlockUserComponent` and service
- integrate block dialog into chat UI

## Testing
- `npm run typecheck`
- `npm run build:prod`


------
https://chatgpt.com/codex/tasks/task_e_685819d6fa48832cb8ed93b4955b925a